### PR TITLE
Add public method to reset internal manager caches

### DIFF
--- a/SGHTTPRequest.h
+++ b/SGHTTPRequest.h
@@ -192,6 +192,11 @@ a new identical request.
 @property (nonatomic, assign) SGHTTPLogging logging;
 
 /**
+ * Reset cached internal operations and reachability managers.
+ */
++ (void)resetManagers;
+
+/**
 * SGHTTP Request Logging (defaults to SGHTTPLogNothing.)  Logging is available for DEBUG builds only.
 */
 + (void)setLogging:(SGHTTPLogging)logging;

--- a/SGHTTPRequest.m
+++ b/SGHTTPRequest.m
@@ -164,8 +164,7 @@ void doOnMain(void(^block)()) {
                                         responseType:(SGHTTPDataType)responseType {
     static dispatch_once_t token = 0;
     dispatch_once(&token, ^{
-        gOperationManagers = NSMutableDictionary.new;
-        gReachabilityManagers = NSMutableDictionary.new;
+        [self.class resetManagers];
     });
 
     id key = [NSString stringWithFormat:@"%@+%@+%@",
@@ -395,6 +394,13 @@ void doOnMain(void(^block)()) {
     }
     gNetworkIndicator = [[SGActivityIndicator alloc] init];
     return gNetworkIndicator;
+}
+
+#pragma mark Reset
+
++ (void)resetManagers {
+    gOperationManagers = NSMutableDictionary.new;
+    gReachabilityManagers = NSMutableDictionary.new;
 }
 
 #pragma mark Logging


### PR DESCRIPTION
In particular, HTTP headers get added in `start` to the operation manager's `requestSerializer`, but then if those headers are cleared elsewhere in the application, the old headers will still be used for future requests. Library clients can use this new `resetManagers` method to delete the old state after, for example, a user logs out.
