### PR TITLE
Fix a race condition.

### DIFF
--- a/SGHTTPRequest.m
+++ b/SGHTTPRequest.m
@@ -213,24 +213,26 @@ void doOnMain(void(^block)()) {
         manager.requestSerializer = AFJSONRequestSerializer.serializer;
     }
 
-    if (url.host.length && !gReachabilityManagers[url.host]) {
-        AFNetworkReachabilityManager *reacher = [AFNetworkReachabilityManager managerForDomain:url
-              .host];
-        if (reacher) {
-            gReachabilityManagers[url.host] = reacher;
+    @synchronized(self) {
+        if (url.host.length && !gReachabilityManagers[url.host]) {
+            AFNetworkReachabilityManager *reacher = [AFNetworkReachabilityManager managerForDomain:url
+                  .host];
+            if (reacher) {
+                gReachabilityManagers[url.host] = reacher;
 
-            reacher.reachabilityStatusChangeBlock = ^(AFNetworkReachabilityStatus status) {
-                switch (status) {
-                    case AFNetworkReachabilityStatusReachableViaWWAN:
-                    case AFNetworkReachabilityStatusReachableViaWiFi:
-                        [self.class runRetryQueueFor:url.host];
-                        break;
-                    case AFNetworkReachabilityStatusNotReachable:
-                    default:
-                        break;
-                }
-            };
-            [reacher startMonitoring];
+                reacher.reachabilityStatusChangeBlock = ^(AFNetworkReachabilityStatus status) {
+                    switch (status) {
+                        case AFNetworkReachabilityStatusReachableViaWWAN:
+                        case AFNetworkReachabilityStatusReachableViaWiFi:
+                            [self.class runRetryQueueFor:url.host];
+                            break;
+                        case AFNetworkReachabilityStatusNotReachable:
+                        default:
+                            break;
+                    }
+                };
+                [reacher startMonitoring];
+            }
         }
     }
 


### PR DESCRIPTION
We are seeing crashes in
  +managerForBaseURL:requestType:responseType:

where the actual crash happens inside NSMutableDictionary -setObject:forKey: .

NSMutableDictionary is not thread safe, so adding @synchronized to guard
the write and read should make this go away.

After putting this fix to our test build we have not seen that crash any more. I have seen an other SGHTTPRequest crash, but that's for another patch, perhaps.
