### PR TITLE
Use AFCompoundResponseSerializer to fix race condition

### DIFF
--- a/SGHTTPRequest/Core/SGHTTPRequest.m
+++ b/SGHTTPRequest/Core/SGHTTPRequest.m
@@ -165,7 +165,7 @@ void doOnMain(void(^block)()) {
         }
 
         id success = ^(NSURLSessionTask *task, id responseObject) {
-            NSString *contentType = ((NSHTTPURLResponse*)task.response).allHeaderFields[@"Content-Type"];
+            NSString *contentType = ((NSHTTPURLResponse*)task.response).MIMEType;
             NSString *errorUserInfoReason;
             switch (self.responseFormat) {
                 case SGHTTPDataTypeJSON:


### PR DESCRIPTION
This fixes an issue that was introduced in https://github.com/seatgeek/SGHTTPRequest/pull/6.

With the prior implementation, multiple requests to a single `baseURL` would overwrite each other's `responseSerializer`s, which could cause errors if they were expecting different content types. `AFCompoundResponseSerializer` avoids this problem, but we should instead use `SGHTTPRequest`'s `responseFormat` to make sure that we still register an error if the response is not of the expected format.