### PR TITLE
Allow top-level arrays to be deserialized

### DIFF
--- a/SGHTTPRequest/Core/SGHTTPRequest.m
+++ b/SGHTTPRequest/Core/SGHTTPRequest.m
@@ -376,7 +376,8 @@ void doOnMain(void(^block)(void)) {
     NSData *responseData = nil;
     NSString *responseString = nil;
 
-    if ([responseObject isKindOfClass:NSDictionary.class]) {
+    if ([responseObject isKindOfClass:NSDictionary.class]
+        || [responseObject isKindOfClass:NSArray.class]) {
         responseData = [NSJSONSerialization dataWithJSONObject:responseObject
                                                            options:NSJSONWritingPrettyPrinted
                                                              error:nil];


### PR DESCRIPTION
Prevents an assertion from being thrown if the object that comes back in the response is an array instead of a dictionary.