### PR TITLE
Adding global request header functionality

### DIFF
--- a/SGHTTPRequest.podspec
+++ b/SGHTTPRequest.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name          = "SGHTTPRequest"
-  s.version       = "1.9.0"
+  s.version       = "1.9.1"
   s.summary       = "A lightweight AFNetworking wrapper for making HTTP requests with minimal code, and callback blocks for success, failure, and retry."
   s.homepage      = "https://github.com/seatgeek/SGHTTPRequest"
   s.license       = { :type => "BSD", :file => "LICENSE" }
   s.author        = "SeatGeek"    
-  s.source        = { :git => "https://github.com/seatgeek/SGHTTPRequest.git", :tag => "1.9.0" }
+  s.source        = { :git => "https://github.com/seatgeek/SGHTTPRequest.git", :tag => "1.9.1" }
   s.requires_arc  = true
   s.dependency    "AFNetworking/NSURLSession", '~>3.0'
   s.dependency    "AFNetworking/Reachability", '~>3.0'

--- a/SGHTTPRequest/Core/SGHTTPRequest.h
+++ b/SGHTTPRequest/Core/SGHTTPRequest.h
@@ -218,6 +218,16 @@ a new identical request.
 @property (nullable, nonatomic, strong) NSDictionary *requestHeaders;
 
 /**
+ * Set the HTTP header fields and values to send with every request.
+ */
++ (void)setGlobalRequestHeaders:(nullable NSDictionary *)globalRequestHeaders;
+
+/**
+* An optional dictionary of HTTP header fields and values to send with every request.
+*/
++ (nullable NSDictionary *)globalRequestHeaders;
+
+/**
 * Whether to show the status bar network activity indicator or not. Default is YES.
 */
 @property (nonatomic, assign) BOOL showActivityIndicator;

--- a/SGHTTPRequest/Core/SGHTTPRequest.m
+++ b/SGHTTPRequest/Core/SGHTTPRequest.m
@@ -145,8 +145,12 @@ void doOnMain(void(^block)(void)) {
                 break;
         }
 
-        for (NSString *field in self.requestHeaders) {
-            [manager.requestSerializer setValue:self.requestHeaders[field] forHTTPHeaderField:field];
+        NSMutableDictionary *combinedHeaders = @{}.mutableCopy;
+        [combinedHeaders addEntriesFromDictionary: SGHTTPRequest.globalRequestHeaders];
+        [combinedHeaders addEntriesFromDictionary: self.requestHeaders];
+
+        for (NSString *field in combinedHeaders) {
+            [manager.requestSerializer setValue:combinedHeaders[field] forHTTPHeaderField:field];
         }
 
         if (self.eTag.length && ![self.eTag isEqualToString:@"Missing"]) {
@@ -681,6 +685,18 @@ static BOOL gAllowNSNulls = YES;
     return gAllowNSNulls;
 }
 
+#pragma mark - Global Request Headers
+
+static NSDictionary *gGlobalRequestHeaders = nil;
+
++ (void)setGlobalRequestHeaders:(NSDictionary *)globalRequestHeaders {
+    gGlobalRequestHeaders = globalRequestHeaders;
+}
+
++ (NSDictionary *)globalRequestHeaders {
+    return gGlobalRequestHeaders;
+}
+
 #pragma mark - Logging
 
 + (void)setLogging:(SGHTTPLogging)logging {
@@ -758,6 +774,7 @@ static BOOL gAllowNSNulls = YES;
     [output appendString:[NSString stringWithFormat:@"%@", self.url]];
     [output appendString:[self boxUpString:@"Request Headers:" fatLine:NO]];
     [output appendString:[NSString stringWithFormat:@"%@", self.requestHeaders]];
+    [output appendString:[NSString stringWithFormat:@"%@", SGHTTPRequest.globalRequestHeaders]];
 
     // this prints out POST Data: / PUT data: etc
     [output appendString:[self boxUpString:[NSString stringWithFormat:@"%@ Data:", requestMethod]


### PR DESCRIPTION
Necessary for https://github.com/seatgeek/iphone-app/issues/8044

Plan is to define the global request headers in the `AppDelegate` near where we define SGQuery globals.

```
[SGHTTPRequest setGlobalRequestHeaders: @{"key": "value"}]
```